### PR TITLE
Fixed get_plugins() undefined

### DIFF
--- a/inc/github.php
+++ b/inc/github.php
@@ -211,12 +211,13 @@ if ( ! class_exists( 'Envato_Market_Github' ) ) :
 		 * @return string
 		 */
 		public function state() {
+			$state = '';
 			$option = 'envato_market_state';
 			$active_plugins = apply_filters( 'active_plugins', get_option( 'active_plugins' ) );
 			if ( in_array( 'envato-market/envato-market.php', $active_plugins ) ) {
 				$state = 'activated';
 				update_option( $option, $state );
-			} else {
+			} elseif ( function_exists( 'get_plugins' ) ) {
 				$state = 'install';
 				update_option( $option, $state );
 				foreach ( array_keys( get_plugins() ) as $plugin ) {


### PR DESCRIPTION
When browsing on the front end of a new site with no API key active the following error was present:

Fatal error: Call to undefined function get_plugins() in /Users/marc/Sites/obox.beta/wp-content/plugins/envato-market/inc/github.php on line 222

I've added a check for the function existing, however, I feel that the plugin should not actually be running this code on the front end of the site.