### PR TITLE
Added ternary operators to check for plugin data

### DIFF
--- a/inc/api.php
+++ b/inc/api.php
@@ -11,7 +11,7 @@ if ( ! class_exists( 'Envato_Market_API' ) && class_exists( 'Envato_Market' ) ) 
 	 * Creates the Envato API connection.
 	 *
 	 * @class Envato_Market_API
-	 * @version 1.0.0
+	 * @version 1.0.0normalize_theme
 	 * @since 1.0.0
 	 */
 	class Envato_Market_API {
@@ -264,14 +264,14 @@ if ( ! class_exists( 'Envato_Market_API' ) && class_exists( 'Envato_Market' ) ) 
 		public function normalize_theme( $theme ) {
 			return array(
 				'id' => $theme['id'],
-				'name' => $theme['wordpress_theme_metadata']['theme_name'],
-				'author' => $theme['wordpress_theme_metadata']['author_name'],
-				'version' => $theme['wordpress_theme_metadata']['version'],
+				'name' => ( isset( $theme['wordpress_theme_metadata']['theme_name'] ) ? $theme['wordpress_theme_metadata']['theme_name'] : NULL ),
+				'author' => ( isset( $theme['wordpress_theme_metadata']['author_name'] ) ? $theme['wordpress_theme_metadata']['author_name'] : NULL ),
+				'version' => ( isset( $theme['wordpress_theme_metadata']['version'] ) ? $theme['wordpress_theme_metadata']['version'] : NULL ),
 				'description' => self::remove_non_unicode( $theme['wordpress_theme_metadata']['description'] ),
-				'url' => $theme['url'],
-				'author_url' => $theme['author_url'],
-				'thumbnail_url' => $theme['thumbnail_url'],
-				'rating' => $theme['rating'],
+				'url' => ( isset( $theme['url'] ) ? $theme['url'] : NULL ),
+				'author_url' => ( isset( $theme['author_url'] ) ? $theme['author_url'] : NULL ),
+				'thumbnail_url' => ( isset( $theme['thumbnail_url'] ) ? $theme['thumbnail_url'] : NULL ),
+				'rating' => ( isset( $theme['rating'] ) ? $theme['rating'] : NULL ),
 			);
 		}
 
@@ -332,19 +332,19 @@ if ( ! class_exists( 'Envato_Market_API' ) && class_exists( 'Envato_Market' ) ) 
 
 			return array(
 				'id' => $plugin['id'],
-				'name' => $plugin['wordpress_plugin_metadata']['plugin_name'],
-				'author' => $plugin['wordpress_plugin_metadata']['author'],
-				'version' => $plugin['wordpress_plugin_metadata']['version'],
+				'name' => ( isset( $plugin['wordpress_plugin_metadata']['plugin_name'] ) ? $plugin['wordpress_plugin_metadata']['plugin_name'] : NULL ),
+				'author' => ( isset( $plugin['wordpress_plugin_metadata']['author'] ) ? $plugin['wordpress_plugin_metadata']['author'] : NULL ),
+				'version' => ( isset( $plugin['wordpress_plugin_metadata']['version'] ) ? $plugin['wordpress_plugin_metadata']['version'] : NULL ),
 				'description' => self::remove_non_unicode( $plugin['wordpress_plugin_metadata']['description'] ),
-				'url' => $plugin['url'],
-				'author_url' => $plugin['author_url'],
-				'thumbnail_url' => $plugin['thumbnail_url'],
-				'landscape_url' => ( $has_landscape ? $plugin['previews']['landscape_preview']['landscape_url'] : '' ),
+				'url' => ( isset( $plugin['url'] ) ? $plugin['url'] : NULL ),
+				'author_url' => ( isset( $plugin['author_url'] ) ? $plugin['author_url'] : NULL ),
+				'thumbnail_url' => ( isset( $plugin['thumbnail_url'] ) ? $plugin['thumbnail_url'] : NULL ),
+				'landscape_url' => ( isset( $plugin['previews']['landscape_preview']['landscape_url'] ) ? $plugin['previews']['landscape_preview']['landscape_url'] : NULL ),
 				'requires' => $requires,
 				'tested' => $tested,
-				'number_of_sales' => $plugin['number_of_sales'],
-				'updated_at' => $plugin['updated_at'],
-				'rating' => $plugin['rating'],
+				'number_of_sales' => ( isset( $plugin['number_of_sales'] ) ? $plugin['number_of_sales'] : NULL ),
+				'updated_at' => ( isset( $plugin['updated_at'] ) ? $plugin['updated_at'] : NULL ),
+				'rating' => ( isset( $plugin['rating'] ) ? $plugin['rating'] : NULL ),
 			);
 		}
 


### PR DESCRIPTION
In some cases the `normalize_theme` and `normalize_plugin` functions returned warnings when certain elements were not defined. I added ternaries around each element in their return arrays to account for missing information in the API.