### PR TITLE
Add `User-Agent` to HTTP requests

### DIFF
--- a/inc/api.php
+++ b/inc/api.php
@@ -117,6 +117,7 @@ if ( ! class_exists( 'Envato_Market_API' ) && class_exists( 'Envato_Market' ) ) 
 			$defaults = array(
 				'headers' => array(
 					'Authorization' => 'Bearer ' . $this->token,
+					'User-Agent' => 'Envato Market WordPress Plugin (' . envato_market()->get_version() . ')',
 				),
 				'timeout' => 20,
 			);


### PR DESCRIPTION
It's a good practice to always send a customised user agent in order to
differentiate the traffic between sources. Adding a user agent with the
version number inside of it is also a valuable tool in order to assess
the versions of your tool still in use in the outside world.

cc @dtbaker who brought this one to my attention.