### PR TITLE
fixed issues with persistent cache providers

### DIFF
--- a/inc/class-envato-market-items.php
+++ b/inc/class-envato-market-items.php
@@ -191,7 +191,7 @@ if ( ! class_exists( 'Envato_Market_Items' ) ) :
 		 */
 		public function wp_plugins( $flush = false ) {
 			if ( empty( self::$wp_plugins ) || true === $flush ) {
-				wp_cache_flush();
+				wp_cache_set( 'plugins', false, 'plugins' );
 				self::$wp_plugins = get_plugins();
 			}
 


### PR DESCRIPTION
Using the plugin with persistent object cache providers (such as redis) will flush the whole cache on every `envato_market_plugins_column` call.
A better solution would be to only invalidate the plugins key in the plugins group in order to get non cached output via the `get_plugins` function.