### PR TITLE
PHP Fatal error:  Uncaught Error: Unsupported operand types

### DIFF
--- a/inc/admin/functions.php
+++ b/inc/admin/functions.php
@@ -185,10 +185,10 @@ function envato_market_themes_column( $group = 'install' ) {
 					<div class="column-rating">
 						<?php
 						if ( ! empty( $theme['rating'] ) ) {
-							if( is_array($theme['rating']) && ! empty( $theme['rating']['count'] )) {
+							if( is_array($theme['rating']) && isset( $theme['rating']['count'] )) {
 							  wp_star_rating(
 								  array(
-									  'rating' => ( $theme['rating']['rating'] / 5 * 100 ),
+									  'rating' => ($theme['rating']['rating'] > 0)?( $theme['rating']['rating'] / 5 * 100 ):0,
 									  'type'   => 'percent',
 									  'number' => $theme['rating']['count'],
 								  )
@@ -196,7 +196,7 @@ function envato_market_themes_column( $group = 'install' ) {
 						  }else{
 							  wp_star_rating(
 								  array(
-									  'rating' => ( $theme['rating'] / 5 * 100 ),
+									  'rating' => isset($theme['rating'] && $theme['rating'] > 0)?( $theme['rating'] / 5 * 100 ):0,
 									  'type'   => 'percent',
 								  )
 							  );


### PR DESCRIPTION
In some cases when there is no rating yet, the plugin will cause a fatal error because of a division through zero.
For checking if a value exists in an array you should use isset instead of empty because empty cast all value to bool and therefore if count = 0 count will be consider as empty so the code go further on line 197 instead of 189.
From the docs:
returns FALSE if var exists and has a non-empty, non-zero value. Otherwise returns TRUE.

The following values are considered to be empty:

    "" (an empty string)
    0 (0 as an integer)
    0.0 (0 as a float)
    "0" (0 as a string)
    NULL
    FALSE
    array() (an empty array)
Source: https://www.php.net/manual/en/function.empty.php