### PR TITLE
updated composer.json to pass validation and therefore add support for composer require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,11 +2,7 @@
   "name": "envato/wp-envato-market",
   "description": "WordPress Theme & Plugin management for the Envato Market.",
   "type": "wordpress-plugin",
-  "dist": {
-    "url": "git@github.com:envato/wp-envato-market.git",
-    "type": "git"
-  },
-  "license": "GPL",
+  "license": "GPL-2.0-or-later",
   "authors": [
     {
       "name": "Envato",


### PR DESCRIPTION
- changed license to use a valid SPDX identifier (see https://spdx.org/licenses/)
- removed "dist" property as it is not a valid property at this location (see https://getcomposer.org/doc/04-schema.md)

The above changes fixes the following exception when trying to require this package with composer (composer require envato/wp-envato-market):
```
[LogicException]
   Downloader "Composer\Downloader\GitDownloader" is a source type downloader and can not be used to download dist for package envato/wp-envato-market-9999999-dev
```

Please also publish releases according to your version number (last release is from 2018 and has version number 2.0.1) but current version is 2.0.6, which means a user has to require "dev-master" instead of using a version number.