### PR TITLE
Broken page error solution

### DIFF
--- a/inc/admin/functions.php
+++ b/inc/admin/functions.php
@@ -197,12 +197,15 @@ function envato_market_themes_column( $group = 'install' ) {
 									)
 								);
 							} else {
-								wp_star_rating(
-									array(
-										'rating' => $theme['rating'] > 0 ? ( $theme['rating'] / 5 * 100 ) : 0,
-										'type'   => 'percent',
-									)
-								);
+								if( !is_array($theme['rating']) ){
+									$theme['rating'] = (int) $theme['rating'];
+									wp_star_rating(
+										array(
+											'rating' => $theme['rating'] > 0 ? ( $theme['rating'] / 5 * 100 ) : 0,
+											'type'   => 'percent',
+										)
+									);
+								}
 							}
 						}
 						?>


### PR DESCRIPTION
Recently I see that the $theme['rating']  will return array if there is no ratings for a theme. So the code will show error and break the page to load. So I added the is_array() function. Also the return is float() if there are ratings so I added (int) converter to solve that issue too. This error appears in PHP v7.2 version.