### PR TITLE
fix: do not force showing notices with hidden class

### DIFF
--- a/sass/envato-market.scss
+++ b/sass/envato-market.scss
@@ -59,7 +59,7 @@
     }
   }
 
-  .notice {
+  .notice:not(.hidden) {
     display: block !important;
     margin-top: 15px;
     margin-bottom: 0;


### PR DESCRIPTION
## Summary

Your implementation to always show notices also shows notices from other plugins.

### Actual Behavior

All notices (also hidden) from other vendors are always visible.

### Steps to reproduce

- Install https://wordpress.org/plugins/real-media-library-lite/
- Navigate to your Envato Market plugin

Real Media Library shows a notice for failing WP REST API requests (using the WP Core class `.hidden`).

### Proposal

Do not force showing notices with explicit `.hidden` class.

### Environment

Not relevant.
