### PR TITLE
Improvements for local testing and development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ composer.lock
 
 # local envs
 .env
+.envrc

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ npm-debug.log
 # Composer
 composer.lock
 /vendor/
+
+# local envs
+.env

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -29,3 +29,6 @@ To release a new version we have to update these two files, the steps for doing 
 1. Get approval and merge the PR
 1. Publish a new github release https://github.com/envato/wp-envato-market/releases/new to match the new version number.
 1. The update will now be live for everyone
+
+### For local testing and development, see the market wiki page for the Envato WordPress Plugin, under the systems menu
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+services:
+  db:
+    image: mariadb:10.6.4-focal
+    command: '--default-authentication-plugin=mysql_native_password'
+    volumes:
+      - db_data:/var/lib/mysql
+    restart: always
+    environment:
+      - MYSQL_ROOT_PASSWORD=somewordpress
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=wordpress
+      - MYSQL_PASSWORD=wordpress
+    expose:
+      - 3306
+      - 33060
+  wordpress:
+    image: wordpress:latest
+    volumes:
+      - wp_data:/var/www/html
+      - ./uploads.ini:/usr/local/etc/php/conf.d/uploads.ini
+      - ./inc/:/var/www/html/wp-content/plugins/envato-market/inc/
+    ports:
+      - 8080:80
+    restart: always
+    extra_hosts:
+      - "themeforest.test:host-gateway"
+    environment:
+      WORDPRESS_DB_HOST: db
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_PASSWORD: wordpress
+      WORDPRESS_DB_NAME: wordpress
+      WP_ENVIRONMENT_TYPE: development
+      WORDPRESS_CONFIG_EXTRA: |
+        define('ENVATO_API_DOMAIN', "${ENVATO_API_DOMAIN}");
+        define('ENVATO_API_HEADERS', ${ENVATO_API_HEADERS});
+        define('MONOLITH_API_PATHS', ${MONOLITH_API_PATHS});
+        define( 'WP_DEBUG', true );
+volumes:
+  db_data:
+  wp_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,12 +29,13 @@ services:
       WORDPRESS_DB_USER: wordpress
       WORDPRESS_DB_PASSWORD: wordpress
       WORDPRESS_DB_NAME: wordpress
-      WP_ENVIRONMENT_TYPE: development
       WORDPRESS_CONFIG_EXTRA: |
         define('ENVATO_API_DOMAIN', "${ENVATO_API_DOMAIN}");
         define('ENVATO_API_HEADERS', ${ENVATO_API_HEADERS});
         define('MONOLITH_API_PATHS', ${MONOLITH_API_PATHS});
         define( 'WP_DEBUG', true );
+        // Disable the following line to test the plugin against the production api.
+        define( 'ENVATO_LOCAL_DEVELOPMENT', true );
 volumes:
   db_data:
   wp_data:

--- a/inc/admin/class-envato-market-admin.php
+++ b/inc/admin/class-envato-market-admin.php
@@ -901,7 +901,10 @@ if ( ! class_exists( 'Envato_Market_Admin' ) && class_exists( 'Envato_Market' ) 
 		 * @since 1.0.0
 		 */
 		public function authorize_total_items() {
-			$response = envato_market()->api()->request( 'https://api.envato.com/v1/market/total-items.json' );
+			$domain = envato_market()->get_envato_api_domain();
+			$path = envato_market()->api()->api_path_for('total-items');
+			$url = $domain . $path;
+			$response = envato_market()->api()->request( $url );
 			$notice   = 'success';
 
 			if ( is_wp_error( $response ) ) {
@@ -960,8 +963,11 @@ if ( ! class_exists( 'Envato_Market_Admin' ) && class_exists( 'Envato_Market' ) 
 		 * @since 1.0.0
 		 */
 		public function authorize_token_permissions() {
+			if (wp_get_environment_type() === 'development') {
+				return 'success';
+			}
+      $notice = 'success';
 			$response = envato_market()->api()->request( 'https://api.envato.com/whoami' );
-			$notice   = 'success';
 
 			if ( is_wp_error( $response ) && ( $response->get_error_code() === 'http_error' || $response->get_error_code() == 500 ) ) {
 				$this->store_additional_error_debug_information( 'An error occured checking token permissions', $response->get_error_message(), $response->get_error_data() );
@@ -1002,7 +1008,9 @@ if ( ! class_exists( 'Envato_Market_Admin' ) && class_exists( 'Envato_Market' ) 
 		 * @since 1.0.0
 		 */
 		public function authorize_items( $type = 'themes' ) {
-			$api_url  = 'https://api.envato.com/v2/market/buyer/list-purchases?filter_by=wordpress-' . $type;
+			$domain = envato_market()->get_envato_api_domain();
+			$path = envato_market()->api()->api_path_for('list-purchases');
+			$api_url      = $domain . $path . '?filter_by=wordpress-' . $type;
 			$response = envato_market()->api()->request( $api_url );
 			$notice   = 'success';
 
@@ -1471,43 +1479,45 @@ if ( ! class_exists( 'Envato_Market_Admin' ) && class_exists( 'Envato_Market' ) 
 
 
 		  // Check authenticated API request
-		  $response = envato_market()->api()->request( 'https://api.envato.com/whoami' );
+			if (wp_get_environment_type() === 'production') {
+				$response = envato_market()->api()->request( 'https://api.envato.com/whoami' );
 
-		  if ( is_wp_error( $response ) ) {
-			  $limits['authentication'] = [
-				  'ok'      => false,
-				  'title'   => 'Envato API Authentication',
-				  'message' => "Not currently authenticated with the Envato API. Please add your API token. " . $response->get_error_message(),
-			  ];
-		  } elseif ( ! isset( $response['scopes'] ) ) {
-			  $limits['authentication'] = [
-				  'ok'      => false,
-				  'title'   => 'Envato API Authentication',
-				  'message' => "Missing API permissions. Please re-create your Envato API token with the correct permissions. ",
-			  ];
-		  } else {
-			  $minimum_scopes    = $this->get_required_permissions();
-			  $maximum_scopes    = array( 'default' => 'Default' ) + $minimum_scopes;
-			  $missing_scopes    = array();
-			  $additional_scopes = array();
-			  foreach ( $minimum_scopes as $required_scope => $required_scope_name ) {
-				  if ( ! in_array( $required_scope, $response['scopes'] ) ) {
-					  // The scope minimum required scope doesn't exist.
-					  $missing_scopes [] = $required_scope;
-				  }
-			  }
-			  foreach ( $response['scopes'] as $scope ) {
-				  if ( ! isset( $maximum_scopes[ $scope ] ) ) {
-					  // The available scope is outside our maximum bounds.
-					  $additional_scopes [] = $scope;
-				  }
-			  }
-			  $limits['authentication'] = [
-				  'ok'      => true,
-				  'title'   => 'Envato API Authentication',
-				  'message' => "Authenticated successfully with correct scopes: " . implode( ', ', $response['scopes'] ),
-			  ];
-		  }
+				if ( is_wp_error( $response ) ) {
+					$limits['authentication'] = [
+						'ok'      => false,
+						'title'   => 'Envato API Authentication',
+						'message' => "Not currently authenticated with the Envato API. Please add your API token. " . $response->get_error_message(),
+					];
+				} elseif ( ! isset( $response['scopes'] ) ) {
+					$limits['authentication'] = [
+						'ok'      => false,
+						'title'   => 'Envato API Authentication',
+						'message' => "Missing API permissions. Please re-create your Envato API token with the correct permissions. ",
+					];
+				} else {
+					$minimum_scopes    = $this->get_required_permissions();
+					$maximum_scopes    = array( 'default' => 'Default' ) + $minimum_scopes;
+					$missing_scopes    = array();
+					$additional_scopes = array();
+					foreach ( $minimum_scopes as $required_scope => $required_scope_name ) {
+						if ( ! in_array( $required_scope, $response['scopes'] ) ) {
+							// The scope minimum required scope doesn't exist.
+							$missing_scopes [] = $required_scope;
+						}
+					}
+					foreach ( $response['scopes'] as $scope ) {
+						if ( ! isset( $maximum_scopes[ $scope ] ) ) {
+							// The available scope is outside our maximum bounds.
+							$additional_scopes [] = $scope;
+						}
+					}
+					$limits['authentication'] = [
+						'ok'      => true,
+						'title'   => 'Envato API Authentication',
+						'message' => "Authenticated successfully with correct scopes: " . implode( ', ', $response['scopes'] ),
+					];
+				}
+			}
 
 		  $debug_enabled      = defined( 'WP_DEBUG' ) && WP_DEBUG;
 		  $limits['wp_debug'] = [

--- a/inc/admin/class-envato-market-admin.php
+++ b/inc/admin/class-envato-market-admin.php
@@ -963,7 +963,7 @@ if ( ! class_exists( 'Envato_Market_Admin' ) && class_exists( 'Envato_Market' ) 
 		 * @since 1.0.0
 		 */
 		public function authorize_token_permissions() {
-			if (wp_get_environment_type() === 'development') {
+			if ( defined('ENVATO_LOCAL_DEVELOPMENT') ) {
 				return 'success';
 			}
       $notice = 'success';
@@ -1479,7 +1479,7 @@ if ( ! class_exists( 'Envato_Market_Admin' ) && class_exists( 'Envato_Market' ) 
 
 
 		  // Check authenticated API request
-			if (wp_get_environment_type() === 'production') {
+			if ( !defined('ENVATO_LOCAL_DEVELOPMENT') ) {
 				$response = envato_market()->api()->request( 'https://api.envato.com/whoami' );
 
 				if ( is_wp_error( $response ) ) {

--- a/inc/class-envato-market-api.php
+++ b/inc/class-envato-market-api.php
@@ -115,13 +115,13 @@ if ( ! class_exists( 'Envato_Market_API' ) && class_exists( 'Envato_Market' ) ) 
 		 */
 		public function request( $url, $args = array() ) {
 			$defaults = array(
-				'sslverify' => wp_get_environment_type() === 'production',
+				'sslverify' => !defined('ENVATO_LOCAL_DEVELOPMENT'),
 				'headers' => $this->request_headers(),
 				'timeout' => 14,
 			);
 			$args     = wp_parse_args( $args, $defaults );
 
-			if ( wp_get_environment_type() === 'production' ) {
+			if ( !defined('ENVATO_LOCAL_DEVELOPMENT') ) {
 				$token = trim( str_replace( 'Bearer', '', $args['headers']['Authorization'] ) );
 				if ( empty( $token ) ) {
 					return new WP_Error( 'api_token_error', __( 'An API token is required.', 'envato-market' ) );
@@ -422,7 +422,7 @@ if ( ! class_exists( 'Envato_Market_API' ) && class_exists( 'Envato_Market' ) ) 
 		}
 
 		public function api_path_for( $path ) {
-			if (wp_get_environment_type() === 'development') {
+			if ( defined('ENVATO_LOCAL_DEVELOPMENT') ) {
 				$paths = MONOLITH_API_PATHS;
 			} else {
 				$paths = array(

--- a/inc/class-envato-market-api.php
+++ b/inc/class-envato-market-api.php
@@ -115,17 +115,17 @@ if ( ! class_exists( 'Envato_Market_API' ) && class_exists( 'Envato_Market' ) ) 
 		 */
 		public function request( $url, $args = array() ) {
 			$defaults = array(
-				'headers' => array(
-					'Authorization' => 'Bearer ' . $this->token,
-					'User-Agent'    => 'WordPress - Envato Market ' . envato_market()->get_version(),
-				),
+				'sslverify' => wp_get_environment_type() === 'production',
+				'headers' => $this->request_headers(),
 				'timeout' => 14,
 			);
 			$args     = wp_parse_args( $args, $defaults );
 
-			$token = trim( str_replace( 'Bearer', '', $args['headers']['Authorization'] ) );
-			if ( empty( $token ) ) {
-				return new WP_Error( 'api_token_error', __( 'An API token is required.', 'envato-market' ) );
+			if ( wp_get_environment_type() === 'production' ) {
+				$token = trim( str_replace( 'Bearer', '', $args['headers']['Authorization'] ) );
+				if ( empty( $token ) ) {
+					return new WP_Error( 'api_token_error', __( 'An API token is required.', 'envato-market' ) );
+				}
 			}
 
 			$debugging_information = [
@@ -200,8 +200,9 @@ if ( ! class_exists( 'Envato_Market_API' ) && class_exists( 'Envato_Market' ) ) 
 			if ( empty( $id ) ) {
 				return false;
 			}
-
-			$url      = 'https://api.envato.com/v2/market/buyer/download?item_id=' . $id . '&shorten_url=true';
+			$domain = envato_market()->get_envato_api_domain();
+			$path = $this->api_path_for('download');
+			$url = $domain . $path . '?item_id=' . $id . '&shorten_url=true';
 			$response = $this->request( $url, $args );
 
 			// @todo Find out which errors could be returned & handle them in the UI.
@@ -238,7 +239,9 @@ if ( ! class_exists( 'Envato_Market_API' ) && class_exists( 'Envato_Market' ) ) 
 		 * @return array The HTTP response.
 		 */
 		public function item( $id, $args = array() ) {
-			$url      = 'https://api.envato.com/v2/market/catalog/item?id=' . $id;
+			$domain = envato_market()->get_envato_api_domain();
+			$path = $this->api_path_for('catalog-item');
+			$url = $domain . $path . '?id=' . $id;
 			$response = $this->request( $url, $args );
 
 			if ( is_wp_error( $response ) || empty( $response ) ) {
@@ -267,7 +270,9 @@ if ( ! class_exists( 'Envato_Market_API' ) && class_exists( 'Envato_Market' ) ) 
 		public function themes( $args = array() ) {
 			$themes = array();
 
-			$url      = 'https://api.envato.com/v2/market/buyer/list-purchases?filter_by=wordpress-themes';
+			$domain = envato_market()->get_envato_api_domain();
+			$path = $this->api_path_for('list-purchases');
+			$url = $domain . $path . '?filter_by=wordpress-themes';
 			$response = $this->request( $url, $args );
 
 			if ( is_wp_error( $response ) || empty( $response ) || empty( $response['results'] ) ) {
@@ -335,7 +340,9 @@ if ( ! class_exists( 'Envato_Market_API' ) && class_exists( 'Envato_Market' ) ) 
 		public function plugins( $args = array() ) {
 			$plugins = array();
 
-			$url      = 'https://api.envato.com/v2/market/buyer/list-purchases?filter_by=wordpress-plugins';
+			$domain = envato_market()->get_envato_api_domain();
+			$path = $this->api_path_for('list-purchases');
+			$url = $domain . $path . '?filter_by=wordpress-plugins';
 			$response = $this->request( $url, $args );
 
 			if ( is_wp_error( $response ) || empty( $response ) || empty( $response['results'] ) ) {
@@ -414,6 +421,21 @@ if ( ! class_exists( 'Envato_Market_API' ) && class_exists( 'Envato_Market' ) ) 
 			return $plugin_normalized;
 		}
 
+		public function api_path_for( $path ) {
+			if (wp_get_environment_type() === 'development') {
+				$paths = MONOLITH_API_PATHS;
+			} else {
+				$paths = array(
+					'download' => '/v2/market/buyer/download',
+					'catalog-item' => '/v2/market/catalog/item',
+					'list-purchases' => '/v2/market/buyer/list-purchases',
+					'total-items' => '/v1/market/total-items.json'
+				);
+			}
+
+			return $paths[$path];
+		}
+
 		/**
 		 * Remove all non unicode characters in a string
 		 *
@@ -425,6 +447,12 @@ if ( ! class_exists( 'Envato_Market_API' ) && class_exists( 'Envato_Market' ) ) 
 		static private function remove_non_unicode( $retval ) {
 			return preg_replace( '/[\x00-\x1F\x80-\xFF]/', '', $retval );
 		}
+
+		private function request_headers() {
+			$user_agent = array('User-Agent' => 'WordPress - Envato Market ' . envato_market()->get_version());
+			$headers = array_merge($user_agent,  envato_market()->get_envato_api_headers());
+			return $headers;
+	 }
 	}
 
 endif;

--- a/inc/class-envato-market.php
+++ b/inc/class-envato-market.php
@@ -176,6 +176,13 @@ if ( ! class_exists( 'Envato_Market' ) ) :
 			$this->page_url    = ENVATO_MARKET_NETWORK_ACTIVATED ? network_admin_url( 'admin.php?page=' . $this->slug ) : admin_url( 'admin.php?page=' . $this->slug );
 			$this->data->admin = true;
 
+			if ( wp_get_environment_type() === 'production' ) {
+				$this->envato_api_domain = 'https://api.envato.com';
+				$this->envato_api_headers = [ 'Authorization' => 'Bearer ' . $this->get_option( 'token' ) ];
+			} else {
+				$this->envato_api_domain = ENVATO_API_DOMAIN;
+				$this->envato_api_headers = ENVATO_API_HEADERS;
+			}
 		}
 
 		/**
@@ -476,6 +483,14 @@ if ( ! class_exists( 'Envato_Market' ) ) :
 		 */
 		public function items() {
 			return Envato_Market_Items::instance();
+		}
+
+		public function get_envato_api_domain() {
+			return $this->envato_api_domain;
+		}
+
+		public function get_envato_api_headers() {
+			return $this->envato_api_headers;
 		}
 	}
 

--- a/inc/class-envato-market.php
+++ b/inc/class-envato-market.php
@@ -175,13 +175,12 @@ if ( ! class_exists( 'Envato_Market' ) ) :
 			$this->plugin_path = ENVATO_MARKET_PATH;
 			$this->page_url    = ENVATO_MARKET_NETWORK_ACTIVATED ? network_admin_url( 'admin.php?page=' . $this->slug ) : admin_url( 'admin.php?page=' . $this->slug );
 			$this->data->admin = true;
-
-			if ( wp_get_environment_type() === 'production' ) {
-				$this->envato_api_domain = 'https://api.envato.com';
-				$this->envato_api_headers = [ 'Authorization' => 'Bearer ' . $this->get_option( 'token' ) ];
-			} else {
+			if ( defined('ENVATO_LOCAL_DEVELOPMENT') ) {
 				$this->envato_api_domain = ENVATO_API_DOMAIN;
 				$this->envato_api_headers = ENVATO_API_HEADERS;
+			} else {
+				$this->envato_api_headers = [ 'Authorization' => 'Bearer ' . $this->get_option( 'token' ) ];
+				$this->envato_api_domain = 'https://api.envato.com';
 			}
 		}
 

--- a/uploads.ini
+++ b/uploads.ini
@@ -1,0 +1,5 @@
+file_uploads = On
+memory_limit = 500M
+upload_max_filesize = 500M
+post_max_size = 500M
+max_execution_time = 600


### PR DESCRIPTION
**Context**
It's been pointed out that the Market-Engineers don't know much about this plugin, but we need to learn more about it.

I wanted to make it easy to set up a local WordPress environment to test WordPress things, and the Envato Market WordPress Plugin itself.

**Changes**
- I've added docker-compose file for WP and a database, with volumes enabling live reloading of php code changes.
- Inject environment variables for local api testing using `.env` file. Ask in market-engineering how to get this.
- I've added a dictionary object with API paths for each environment. 
- Make the whoami request only run in production, as well as a few other snippets of code that won't work locally.

I've you're new to this repo, I suggest following the instructions I've added in the [market wiki](https://docs.envato.net/market/systems/envato-wordpress-plugin.html), since this is a public repo.

Then review the files in this order:
- docker-compose.yml
- inc/class-envato-market.php
- inc/class-envato-market-api.php
- inc/admin/class-envato-market-admin.php

If these changes are approved, I'll merge them, and then release a patch version of the plugin to distinguish these changes. I think that's wise in case there are issues (I don't think there are any).

**Testing**
- I've tested this using the local set up.
- I have also tested the new package against the production api, and the themes from Dave Baker's api key were viewable and downloadable
![Screenshot 2023-03-08 at 1 30 05 PM](https://user-images.githubusercontent.com/10747958/223590609-21e21f24-95c1-4d1f-9351-25118dea5823.png)