### PR TITLE
Make docker-compose up nicer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,8 +52,8 @@ services:
       WORDPRESS_DB_PASSWORD: wordpress
       WORDPRESS_DB_NAME: wordpress
       WORDPRESS_CONFIG_EXTRA: |
-        if( !empty("${ENVATO_API_DOMAIN}") ){ 
-          define('ENVATO_API_DOMAIN', $ENVATO_API_DOMAIN);
+        if( !empty("$ENVATO_API_DOMAIN") ){ 
+          define('ENVATO_API_DOMAIN', "$ENVATO_API_DOMAIN");
           define('ENVATO_API_HEADERS', $ENVATO_API_HEADERS);
           define('MONOLITH_API_PATHS', $MONOLITH_API_PATHS);
           define( 'WP_DEBUG', true );

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
     volumes:
       - wp_data:/var/www/html
       - ./uploads.ini:/usr/local/etc/php/conf.d/uploads.ini
-      - ./inc/:/var/www/html/wp-content/plugins/envato-market/inc/
+      - ./:/var/www/html/wp-content/plugins/envato-market/
     ports:
       - 8080:80
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,28 @@ services:
     expose:
       - 3306
       - 33060
+    healthcheck:
+      test: mysqladmin ping -h 127.0.0.1 -u $$MYSQL_USER --password=$$MYSQL_PASSWORD
+      start_period: 5s
+      interval: 5s
+      timeout: 5s
+      retries: 55
+  wpcli:
+    image: wordpress:cli
+    depends_on:
+      wordpress:
+        condition: service_started
+      db:
+        condition: service_healthy
+    user: www-data:www-data
+    command: wp core install --url=localhost:8080 --title=WPDev --admin_user=dev --admin_password=dev --admin_email=admin@example.com
+    volumes:
+      - wp_data:/var/www/html
+    environment:
+      WORDPRESS_DB_HOST: db
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_PASSWORD: wordpress
+      WORDPRESS_DB_NAME: wordpress
   wordpress:
     image: wordpress:latest
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,12 +52,14 @@ services:
       WORDPRESS_DB_PASSWORD: wordpress
       WORDPRESS_DB_NAME: wordpress
       WORDPRESS_CONFIG_EXTRA: |
-        define('ENVATO_API_DOMAIN', "${ENVATO_API_DOMAIN}");
-        define('ENVATO_API_HEADERS', ${ENVATO_API_HEADERS});
-        define('MONOLITH_API_PATHS', ${MONOLITH_API_PATHS});
-        define( 'WP_DEBUG', true );
-        // Disable the following line to test the plugin against the production api.
-        define( 'ENVATO_LOCAL_DEVELOPMENT', true );
+        if( !empty("${ENVATO_API_DOMAIN}") ){ 
+          define('ENVATO_API_DOMAIN', $ENVATO_API_DOMAIN);
+          define('ENVATO_API_HEADERS', $ENVATO_API_HEADERS);
+          define('MONOLITH_API_PATHS', $MONOLITH_API_PATHS);
+          define( 'WP_DEBUG', true );
+          // Disable the following line to test the plugin against the production api.
+          define( 'ENVATO_LOCAL_DEVELOPMENT', true );
+        }
 volumes:
   db_data:
   wp_data:


### PR DESCRIPTION
## Context

- During local development
- Running `docker-compose up` for the first time still required a bunch of manual setup steps in the web browser to install WordPress and the Market Plugin.

## Changes

Basically now running `docker-compose up` will do all the things including installing WordPress and the Market Plugin, so you just need to go to `localhost:8080/wp-admin/` and login.

- Include `wpcli` in the docker-compose file
- Tell `wpcli` to wait for the database to be healthy before running
- Make `wpcli` install a default WordPress website with a default `dev/dev` user account.
- Mount the entire plugin folder as a volume in the `wp-content/plugins/` folder, so it doesn't need to be installed via zip any more.