### PR TITLE
Fix php 8.2 deprecation messages

### DIFF
--- a/inc/admin/class-envato-market-admin.php
+++ b/inc/admin/class-envato-market-admin.php
@@ -1360,7 +1360,7 @@ if ( ! class_exists( 'Envato_Market_Admin' ) && class_exists( 'Envato_Market' ) 
 			  $limits['memory_limit'] = [
 				  'title'   => 'PHP Memory Limit',
 				  'ok'      => $memory_limit_ok,
-				  'message' => $memory_limit_ok ? "is ok at ${memory_limit_in_mb}." : "${memory_limit_in_mb} may be too small. If you are having issues please set your PHP memory limit to at least 256M - or ask your hosting provider to do this if you're unsure."
+				  'message' => $memory_limit_ok ? "is ok at {$memory_limit_in_mb}." : "{$memory_limit_in_mb} may be too small. If you are having issues please set your PHP memory limit to at least 256M - or ask your hosting provider to do this if you're unsure."
 			  ];
 		  } catch ( \Exception $e ) {
 			  $limits['memory_limit'] = [
@@ -1381,7 +1381,7 @@ if ( ! class_exists( 'Envato_Market_Admin' ) && class_exists( 'Envato_Market' ) 
 			  $limits['upload'] = [
 				  'ok'      => $upload_max_filesize_ok,
 				  'title'   => 'PHP Upload Limits',
-				  'message' => $upload_max_filesize_ok ? "is ok at $upload_max_filesize_in_mb." : "$upload_max_filesize_in_mb may be too small. If you are having issues please set your PHP upload limits to at least ${upload_size_desired}M - or ask your hosting provider to do this if you're unsure.",
+				  'message' => $upload_max_filesize_ok ? "is ok at $upload_max_filesize_in_mb." : "$upload_max_filesize_in_mb may be too small. If you are having issues please set your PHP upload limits to at least {$upload_size_desired}M - or ask your hosting provider to do this if you're unsure.",
 			  ];
 		  } catch ( \Exception $e ) {
 			  $limits['upload'] = [
@@ -1419,7 +1419,7 @@ if ( ! class_exists( 'Envato_Market_Admin' ) && class_exists( 'Envato_Market' ) 
 			  $limits['max_execution_time'] = [
 				  'ok'      => $max_execution_time_ok,
 				  'title'   => 'PHP Execution Time',
-				  'message' => $max_execution_time_ok ? "PHP execution time limit is ok at ${max_execution_time}." : "$max_execution_time is too small. Please set your PHP max execution time to at least $max_execution_time_desired - or ask your hosting provider to do this if you're unsure.",
+				  'message' => $max_execution_time_ok ? "PHP execution time limit is ok at {$max_execution_time}." : "$max_execution_time is too small. Please set your PHP max execution time to at least $max_execution_time_desired - or ask your hosting provider to do this if you're unsure.",
 			  ];
 		  } catch ( \Exception $e ) {
 			  $limits['max_execution_time'] = [


### PR DESCRIPTION
Hi there

We received some PHP 8.2 Deprecation Messages for this plugin.
Creating a small PR to fix this:

[10-Jul-2023 12:45:55 UTC] PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /wp-content/plugins/envato-market/inc/admin/class-envato-market-admin.php on line 1355

FYI: @ostigley @dtbaker 