### PR TITLE
Fix bug with themes not loading.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,9 +10,8 @@ services:
       - MYSQL_DATABASE=wordpress
       - MYSQL_USER=wordpress
       - MYSQL_PASSWORD=wordpress
-    expose:
-      - 3306
-      - 33060
+    ports:
+      - 33006:3306
     healthcheck:
       test: mysqladmin ping -h 127.0.0.1 -u $$MYSQL_USER --password=$$MYSQL_PASSWORD
       start_period: 5s
@@ -51,12 +50,14 @@ services:
       WORDPRESS_DB_USER: wordpress
       WORDPRESS_DB_PASSWORD: wordpress
       WORDPRESS_DB_NAME: wordpress
+      WORDPRESS_DEBUG: 1
       WORDPRESS_CONFIG_EXTRA: |
-        if( !empty("$ENVATO_API_DOMAIN") ){ 
+        define( 'WP_DEBUG_LOG', true);
+        define( 'WP_DEBUG_DISPLAY', true );
+        if( !empty("$ENVATO_API_DOMAIN") ){
           define('ENVATO_API_DOMAIN', "$ENVATO_API_DOMAIN");
           define('ENVATO_API_HEADERS', $ENVATO_API_HEADERS);
           define('MONOLITH_API_PATHS', $MONOLITH_API_PATHS);
-          define( 'WP_DEBUG', true );
           // Disable the following line to test the plugin against the production api.
           define( 'ENVATO_LOCAL_DEVELOPMENT', true );
         }

--- a/inc/admin/functions.php
+++ b/inc/admin/functions.php
@@ -458,3 +458,21 @@ function envato_market_plugins_column( $group = 'install' ) {
 		<?php
 	endforeach;
 }
+
+/**
+ * A handy method for logging to the st_out / and or debug_log
+ * Use: write_log("My variable is {$variable}")
+ */
+if (!function_exists('write_log') && defined('ENVATO_LOCAL_DEVELOPMENT')) {
+
+	function write_log($log) {
+
+		if (is_array($log) || is_object($log)) {
+				error_log(print_r($log, true));
+		} else {
+				error_log($log);
+		}
+
+	}
+
+}

--- a/inc/class-envato-market-items.php
+++ b/inc/class-envato-market-items.php
@@ -372,7 +372,7 @@ if ( ! class_exists( 'Envato_Market_Items' ) ) :
 			$themes_transient = get_site_transient( envato_market()->get_option_name() . '_themes' );
 			self::$themes = is_array($themes_transient) ? $themes_transient : array();
 
-			if ( false === self::$themes || true === $forced ) {
+			if ( empty(self::$themes) || true === $forced ) {
 				$themes = envato_market()->api()->themes();
 				foreach ( envato_market()->get_option( 'items', array() ) as $item ) {
 					if ( empty( $item ) ) {
@@ -409,7 +409,7 @@ if ( ! class_exists( 'Envato_Market_Items' ) ) :
 			$plugins_transient = get_site_transient( envato_market()->get_option_name() . '_plugins' );
 			self::$plugins = is_array($plugins_transient) ? $plugins_transient : array();
 
-			if ( false === self::$plugins || true === $forced ) {
+			if ( empty(self::$plugins) || true === $forced ) {
 				$plugins = envato_market()->api()->plugins();
 				foreach ( envato_market()->get_option( 'items', array() ) as $item ) {
 					if ( empty( $item ) ) {


### PR DESCRIPTION
In a [previous PR](https://github.com/envato/wp-envato-market/pull/308) we fixed a deprecation warning, but missed the array equality check.

This pr fixes that up so themes load.

Also, some dev debugging tweaks

I'll package up a new release in a separate PR