### PR TITLE
Enhance ajax calls with additional current_user_can checks

### DIFF
--- a/inc/admin/class-envato-market-admin.php
+++ b/inc/admin/class-envato-market-admin.php
@@ -1189,6 +1189,8 @@ if ( ! class_exists( 'Envato_Market_Admin' ) && class_exists( 'Envato_Market' ) 
 				wp_send_json_error( array( 'message' => __( 'The Token is missing.', 'envato-market' ) ) );
 			} elseif ( empty( $_POST['id'] ) ) {
 				wp_send_json_error( array( 'message' => __( 'The Item ID is missing.', 'envato-market' ) ) );
+			} elseif ( ! current_user_can( 'install_themes' ) || ! current_user_can( 'install_plugins' ) ) {
+				wp_send_json_error( array( 'message' => __( 'User not allowed to install items.', 'envato-market' ) ) );
 			}
 
 			$args = array(
@@ -1290,6 +1292,8 @@ if ( ! class_exists( 'Envato_Market_Admin' ) && class_exists( 'Envato_Market' ) 
 				wp_send_json_error( 'bad_method' );
 			} elseif ( empty( $_POST['id'] ) ) {
 				wp_send_json_error( array( 'message' => __( 'The Item ID is missing.', 'envato-market' ) ) );
+			} elseif ( ! current_user_can( 'delete_plugins' ) || ! current_user_can( 'delete_themes' ) ) {
+				wp_send_json_error( array( 'message' => __( 'User not allowed to update items.', 'envato-market' ) ) );
 			}
 
 			$options = get_option( envato_market()->get_option_name(), array() );
@@ -1332,6 +1336,8 @@ if ( ! class_exists( 'Envato_Market_Admin' ) && class_exists( 'Envato_Market' ) 
 			} elseif ( 'POST' !== $_SERVER['REQUEST_METHOD'] ) {
 				status_header( 405 );
 				wp_send_json_error( 'bad_method' );
+			} elseif ( ! current_user_can( 'install_themes' ) || ! current_user_can( 'install_plugins' ) ) {
+				wp_send_json_error( array( 'message' => __( 'User not allowed to install items.', 'envato-market' ) ) );
 			}
 
 			$limits = $this->get_server_limits();

--- a/inc/class-envato-market-github.php
+++ b/inc/class-envato-market-github.php
@@ -351,7 +351,12 @@ if ( ! class_exists( 'Envato_Market_Github' ) ) :
 		 * @since 1.0.0
 		 */
 		public function dismiss_notice() {
-			check_ajax_referer( self::AJAX_ACTION, 'nonce' );
+			if ( ! check_ajax_referer( self::AJAX_ACTION, 'nonce', false ) ) {
+				status_header( 400 );
+				wp_send_json_error( 'bad_nonce' );
+			} elseif ( ! current_user_can( 'update_plugins' ) ) {
+				wp_send_json_error( array( 'message' => __( 'User not allowed to update items.', 'envato-market' ) ) );
+			}
 
 			update_option( self::AJAX_ACTION, 'dismissed' );
 			wp_send_json_success();


### PR DESCRIPTION
Previously these checks were protected via standard WordPress security nonce checks. We can enhance this security by additionally checking the current users WordPress capabilities.

We already perform "current_user_can" checks elsewhere when installing a theme or plugin, this just moves the check further up the chain.