### PR TITLE
fix: guard against missing description in plugin metadata

### DIFF
--- a/inc/class-envato-market-api.php
+++ b/inc/class-envato-market-api.php
@@ -388,7 +388,7 @@ if ( ! class_exists( 'Envato_Market_API' ) && class_exists( 'Envato_Market' ) ) 
 				'name'            => ( ! empty( $plugin['wordpress_plugin_metadata']['plugin_name'] ) ? $plugin['wordpress_plugin_metadata']['plugin_name'] : '' ),
 				'author'          => ( ! empty( $plugin['wordpress_plugin_metadata']['author'] ) ? $plugin['wordpress_plugin_metadata']['author'] : '' ),
 				'version'         => ( ! empty( $plugin['wordpress_plugin_metadata']['version'] ) ? $plugin['wordpress_plugin_metadata']['version'] : '' ),
-				'description'     => self::remove_non_unicode( strip_tags( $plugin['wordpress_plugin_metadata']['description'] ) ),
+				'description'     => ( ! empty( $plugin['wordpress_plugin_metadata']['description'] ) ? self::remove_non_unicode( strip_tags( $plugin['wordpress_plugin_metadata']['description'] ) ) : '' ),
 				'url'             => ( ! empty( $plugin['url'] ) ? $plugin['url'] : '' ),
 				'author_url'      => ( ! empty( $plugin['author_url'] ) ? $plugin['author_url'] : '' ),
 				'thumbnail_url'   => ( ! empty( $plugin['thumbnail_url'] ) ? $plugin['thumbnail_url'] : '' ),


### PR DESCRIPTION


## Context
Reported via support ticket [#4186310 ("Envato Market 2.0.13 plugin errors")](https://envatomarketplaces.zendesk.com/agent/tickets/4198235/conversations/b39580c8-43dc-11f1-8683-721e966d39a2). User saw this in their WordPress error log on every update poll:

```
PHP Warning: Undefined array key "description" in
/wp-content/plugins/envato-market/inc/class-envato-market-api.php on line 391
```

Root cause: line 391 was the only entry in the `$plugin_normalized` array that read its key directly instead of using the `! empty(...) ? ... : ''` defensive pattern used by every sibling field on lines 388–390 and 392+. When the Envato API omits `description` for an item, PHP 8 emits the warning.
## Change

- Add a check for an empty description

## Testing on local
### Before the 'is empty' check
<img width="1123" height="502" alt="Screenshot 2026-05-12 at 11 11 40" src="https://github.com/user-attachments/assets/d75df14e-1266-4306-b8df-dec375986085" />

### After the 'is empty' check
<img width="1120" height="452" alt="Screenshot 2026-05-12 at 14 29 48" src="https://github.com/user-attachments/assets/56fb099c-13b9-4c67-894a-b9e806625866" />

## Code Author General Checklist
- [x] I have notified the [Market team][market-engineering] of my changes (link to this PR).
- [x] I kept my pull request small so it can be reviewed easier.
- [x] My code follows the project's coding and style guidelines.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] Where needed, I have consulted subject matter experts to gain confidence in the change's correctness.
- [ ] I have notified the [Data team][data-team-slack] of any database changes if applicable.
- [ ] I have updated the [Dewey database schema][dewey-db-schema] with the latest changes if applicable.
- [ ] I will monitor the build status on [Buildkite], ensure the deployment passes on [Samson] via [#market-deploy] and check if my changes introduce any errors on [Rollbar] and [Datadog].

[market-engineering]: https://envato.slack.com/archives/market-engineering/
[Buildkite]: https://buildkite.com/envato-marketplaces/marketplace
[data-team-slack]: https://envato.slack.com/messages/C8TCNLUJD
[dewey-db-schema]: https://github.com/envato/dewey/blob/main/script/mysql/structure.sql
[#market-deploy]: https://envato.slack.com/archives/market-deploy/
[Samson]: https://deploy.platform.envato.net/projects/marketplace
[Rollbar]: https://rollbar.com/envato/marketplace/items/
[Datadog]: https://envato-customer.datadoghq.com/dashboard/96s-798-pee/marketplace

[MTMS-4157]: https://envato.atlassian.net/browse/MTMS-4157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

.